### PR TITLE
eeg: Integrate libmed based EEG providers 

### DIFF
--- a/kb/eeg/eeg_montage_transform.ont
+++ b/kb/eeg/eeg_montage_transform.ont
@@ -1,0 +1,405 @@
+{
+    "last_id": "60",
+    "namespaces": {
+        "default": "http://knova.ru/user/1617490480029",
+        "ontolis-avis": "http://knova.ru/ontolis-avis",
+        "owl": "http://www.w3.org/2002/07/owl",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+        "xsd": "http://www.w3.org/2001/XMLSchema"
+    },
+    "nodes": [
+        {
+            "attributes": {
+            },
+            "id": "1",
+            "name": "Filter",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 618,
+            "position_y": 402
+        },
+        {
+            "attributes": {
+            },
+            "id": "2",
+            "name": "Root",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 607,
+            "position_y": 292
+        },
+        {
+            "attributes": {
+            },
+            "id": "3",
+            "name": "Transform by Montage",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 674,
+            "position_y": 541
+        },
+        {
+            "attributes": {
+            },
+            "id": "6",
+            "name": "Input",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 131,
+            "position_y": 405
+        },
+        {
+            "attributes": {
+            },
+            "id": "7",
+            "name": "Output",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 137,
+            "position_y": 615
+        },
+        {
+            "attributes": {
+            },
+            "id": "8",
+            "name": "EEG In",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 307,
+            "position_y": 465
+        },
+        {
+            "attributes": {
+            },
+            "id": "11",
+            "name": "Array",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 167,
+            "position_y": 752
+        },
+        {
+            "attributes": {
+            },
+            "id": "13",
+            "name": "Type",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 20,
+            "position_y": 858
+        },
+        {
+            "attributes": {
+                "path": "lib/eeg/montage_transform.py"
+            },
+            "id": "25",
+            "name": "Transform by Montage Worker",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 795,
+            "position_y": 417
+        },
+        {
+            "attributes": {
+            },
+            "id": "26",
+            "name": "ServerSideWorker",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 793,
+            "position_y": 295
+        },
+        {
+            "attributes": {
+            },
+            "id": "28",
+            "name": "Python",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 966,
+            "position_y": 297
+        },
+        {
+            "attributes": {
+                "default": "cap21"
+            },
+            "id": "31",
+            "name": "Montage Name",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 585,
+            "position_y": 707
+        },
+        {
+            "attributes": {
+            },
+            "id": "32",
+            "name": "Setting",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 590,
+            "position_y": 842
+        },
+        {
+            "attributes": {
+            },
+            "id": "33",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 362,
+            "position_y": 858
+        },
+        {
+            "attributes": {
+            },
+            "id": "38",
+            "name": "Labels",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "position_x": 355,
+            "position_y": 621
+        },
+        {
+            "attributes": {
+            },
+            "id": "42",
+            "name": "Montage Schema",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 368,
+            "position_y": 406
+        },
+        {
+            "attributes": {
+            },
+            "id": "43",
+            "name": "MontageSchema",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 12,
+            "position_y": 315
+        },
+        {
+            "attributes": {
+            },
+            "id": "53",
+            "name": "EEG Out",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 302,
+            "position_y": 566
+        },
+        {
+            "attributes": {
+            },
+            "id": "58",
+            "name": "Grid",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 144,
+            "position_y": 518
+        }
+    ],
+    "relations": [
+        {
+            "attributes": {
+            },
+            "destination_node_id": "1",
+            "id": "4",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "2",
+            "id": "5",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "1"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "8",
+            "id": "14",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "17",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "8"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "13",
+            "id": "23",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "11"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "3",
+            "id": "27",
+            "name": "is_instance",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "25"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "28",
+            "id": "29",
+            "name": "languale",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "25"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "26",
+            "id": "30",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "25"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "33",
+            "id": "34",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "31",
+            "id": "35",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "32",
+            "id": "36",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "13",
+            "id": "37",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "33"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "38",
+            "id": "39",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "41",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1617490480029",
+            "source_node_id": "38"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "43",
+            "id": "44",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "42"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "13",
+            "id": "45",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "43"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "42",
+            "id": "46",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "47",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "42"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "33",
+            "id": "51",
+            "name": "base_type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "38"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "11",
+            "id": "52",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "38"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "54",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "53"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "53",
+            "id": "57",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "58",
+            "id": "59",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "8"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "58",
+            "id": "60",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "53"
+        }
+    ],
+    "visualize_ont_path": ""
+}

--- a/kb/eeg/eegchart.ont
+++ b/kb/eeg/eegchart.ont
@@ -1,5 +1,5 @@
 {
-    "last_id": "38",
+    "last_id": "58",
     "namespaces": {
         "default": "http://knova.ru/user/1611500337650",
         "ontolis-avis": "http://knova.ru/ontolis-avis",
@@ -15,8 +15,8 @@
             "id": "1",
             "name": "EEG Chart",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 285,
-            "position_y": 325
+            "position_x": 882,
+            "position_y": 386
         },
         {
             "attributes": {
@@ -24,8 +24,8 @@
             "id": "2",
             "name": "VisualObject",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 277,
-            "position_y": 260
+            "position_x": 884,
+            "position_y": 280
         },
         {
             "attributes": {
@@ -33,8 +33,8 @@
             "id": "3",
             "name": "Root",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 302,
-            "position_y": 200
+            "position_x": 880,
+            "position_y": 178
         },
         {
             "attributes": {
@@ -42,8 +42,8 @@
             "id": "4",
             "name": "EEG",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 267,
-            "position_y": 382
+            "position_x": 762,
+            "position_y": 400
         },
         {
             "attributes": {
@@ -51,8 +51,8 @@
             "id": "5",
             "name": "Grid",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 266,
-            "position_y": 445
+            "position_x": 546,
+            "position_y": 432
         },
         {
             "attributes": {
@@ -60,8 +60,8 @@
             "id": "6",
             "name": "Input",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 200,
-            "position_y": 327
+            "position_x": 602,
+            "position_y": 342
         },
         {
             "attributes": {
@@ -70,8 +70,8 @@
             "id": "7",
             "name": "EEG Chart Worker",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 445,
-            "position_y": 325
+            "position_x": 1085,
+            "position_y": 398
         },
         {
             "attributes": {
@@ -79,8 +79,8 @@
             "id": "8",
             "name": "ClientSideWorker",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 438,
-            "position_y": 259
+            "position_x": 1058,
+            "position_y": 137
         },
         {
             "attributes": {
@@ -88,8 +88,8 @@
             "id": "9",
             "name": "JavaScript",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 484,
-            "position_y": 481
+            "position_x": 1225,
+            "position_y": 137
         },
         {
             "attributes": {
@@ -97,8 +97,8 @@
             "id": "15",
             "name": "Type",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 381,
-            "position_y": 449
+            "position_x": 378,
+            "position_y": 541
         },
         {
             "attributes": {
@@ -107,8 +107,8 @@
             "id": "21",
             "name": "ChartJS",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 621,
-            "position_y": 264
+            "position_x": 1299,
+            "position_y": 277
         },
         {
             "attributes": {
@@ -116,8 +116,8 @@
             "id": "22",
             "name": "Dependency",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 715,
-            "position_y": 225
+            "position_x": 1490,
+            "position_y": 248
         },
         {
             "attributes": {
@@ -126,8 +126,8 @@
             "id": "26",
             "name": "ChartJS CSS",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 780,
-            "position_y": 298
+            "position_x": 1296,
+            "position_y": 328
         },
         {
             "attributes": {
@@ -135,8 +135,63 @@
             "id": "29",
             "name": "CSS",
             "namespace": "http://knova.ru/user/1611500337650",
-            "position_x": 881,
-            "position_y": 361
+            "position_x": 1314,
+            "position_y": 427
+        },
+        {
+            "attributes": {
+            },
+            "id": "39",
+            "name": "Labels",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 744,
+            "position_y": 268
+        },
+        {
+            "attributes": {
+                "default": 100
+            },
+            "id": "43",
+            "name": "History",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 880,
+            "position_y": 509
+        },
+        {
+            "attributes": {
+            },
+            "id": "44",
+            "name": "Number",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 626,
+            "position_y": 537
+        },
+        {
+            "attributes": {
+            },
+            "id": "49",
+            "name": "Setting",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 878,
+            "position_y": 623
+        },
+        {
+            "attributes": {
+            },
+            "id": "53",
+            "name": "Array",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 540,
+            "position_y": 263
+        },
+        {
+            "attributes": {
+            },
+            "id": "56",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 542,
+            "position_y": 201
         }
     ],
     "relations": [
@@ -274,6 +329,96 @@
             "name": "language",
             "namespace": "http://knova.ru/user/1611500337650",
             "source_node_id": "26"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "39",
+            "id": "40",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "1"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "42",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "39"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "43",
+            "id": "46",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "1"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "49",
+            "id": "50",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "43"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "44",
+            "id": "51",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "43"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "15",
+            "id": "52",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "44"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "53",
+            "id": "54",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "39"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "15",
+            "id": "55",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "53"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "15",
+            "id": "57",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "56"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "56",
+            "id": "58",
+            "name": "base_type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "39"
         }
     ],
     "visualize_ont_path": ""

--- a/kb/eeg/impedance.ont
+++ b/kb/eeg/impedance.ont
@@ -1,5 +1,5 @@
 {
-    "last_id": "30",
+    "last_id": "42",
     "namespaces": {
         "default": "http://knova.ru/user/1615325175122",
         "ontolis-avis": "http://knova.ru/ontolis-avis",
@@ -15,8 +15,8 @@
             "id": "1",
             "name": "Root",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 308,
-            "position_y": 200
+            "position_x": 197,
+            "position_y": 96
         },
         {
             "attributes": {
@@ -24,8 +24,8 @@
             "id": "2",
             "name": "VisualObject",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 264,
-            "position_y": 261
+            "position_x": 200,
+            "position_y": 188
         },
         {
             "attributes": {
@@ -33,8 +33,8 @@
             "id": "3",
             "name": "Impedance",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 288,
-            "position_y": 300
+            "position_x": 197,
+            "position_y": 280
         },
         {
             "attributes": {
@@ -42,8 +42,8 @@
             "id": "4",
             "name": "EEG",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 259,
-            "position_y": 360
+            "position_x": 34,
+            "position_y": 276
         },
         {
             "attributes": {
@@ -51,8 +51,8 @@
             "id": "5",
             "name": "Grid",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 244,
-            "position_y": 394
+            "position_x": -256,
+            "position_y": 272
         },
         {
             "attributes": {
@@ -60,8 +60,8 @@
             "id": "6",
             "name": "Type",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 219,
-            "position_y": 435
+            "position_x": -262,
+            "position_y": 549
         },
         {
             "attributes": {
@@ -79,8 +79,8 @@
             "id": "13",
             "name": "ClientSideWorker",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 461,
-            "position_y": 216
+            "position_x": 448,
+            "position_y": 120
         },
         {
             "attributes": {
@@ -88,8 +88,8 @@
             "id": "14",
             "name": "JavaScript",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 503,
-            "position_y": 317
+            "position_x": 609,
+            "position_y": 121
         },
         {
             "attributes": {
@@ -97,8 +97,8 @@
             "id": "18",
             "name": "Input",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 200,
-            "position_y": 331
+            "position_x": -148,
+            "position_y": 321
         },
         {
             "attributes": {
@@ -107,8 +107,8 @@
             "id": "20",
             "name": "Threshold",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 330,
-            "position_y": 359
+            "position_x": 199,
+            "position_y": 404
         },
         {
             "attributes": {
@@ -116,8 +116,8 @@
             "id": "21",
             "name": "Number",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 327,
-            "position_y": 395
+            "position_x": 193,
+            "position_y": 546
         },
         {
             "attributes": {
@@ -125,8 +125,8 @@
             "id": "22",
             "name": "Setting",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 390,
-            "position_y": 319
+            "position_x": 339,
+            "position_y": 538
         },
         {
             "attributes": {
@@ -134,8 +134,8 @@
             "id": "27",
             "name": "Dependency",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 660,
-            "position_y": 236
+            "position_x": 806,
+            "position_y": 112
         },
         {
             "attributes": {
@@ -144,8 +144,35 @@
             "id": "28",
             "name": "21_10-20.svg",
             "namespace": "http://knova.ru/user/1615325175122",
-            "position_x": 656,
-            "position_y": 284
+            "position_x": 724,
+            "position_y": 203
+        },
+        {
+            "attributes": {
+            },
+            "id": "31",
+            "name": "Array",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": -179,
+            "position_y": 434
+        },
+        {
+            "attributes": {
+            },
+            "id": "32",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": -77,
+            "position_y": 492
+        },
+        {
+            "attributes": {
+            },
+            "id": "37",
+            "name": "Labels",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 24,
+            "position_y": 352
         }
     ],
     "relations": [
@@ -283,6 +310,78 @@
             "name": "is_a",
             "namespace": "http://knova.ru/user/1615325175122",
             "source_node_id": "28"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "31",
+            "id": "33",
+            "name": "",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "34",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "36",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "32"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "37",
+            "id": "38",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "37",
+            "id": "39",
+            "name": "",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "37"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "18",
+            "id": "40",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "37"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "31",
+            "id": "41",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "37"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "32",
+            "id": "42",
+            "name": "base_type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "37"
         }
     ],
     "visualize_ont_path": ""

--- a/kb/eeg/med_dummy.ont
+++ b/kb/eeg/med_dummy.ont
@@ -1,0 +1,398 @@
+{
+    "last_id": "50",
+    "namespaces": {
+        "default": "http://knova.ru/user/1608539508915",
+        "ontolis-avis": "http://knova.ru/ontolis-avis",
+        "owl": "http://www.w3.org/2002/07/owl",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+        "xsd": "http://www.w3.org/2001/XMLSchema"
+    },
+    "nodes": [
+        {
+            "attributes": {
+            },
+            "id": "1",
+            "name": "DataSource",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 776,
+            "position_y": 324
+        },
+        {
+            "attributes": {
+            },
+            "id": "2",
+            "name": "Root",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 773,
+            "position_y": 210
+        },
+        {
+            "attributes": {
+            },
+            "id": "3",
+            "name": "Dummy EEG",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 776,
+            "position_y": 448
+        },
+        {
+            "attributes": {
+            },
+            "id": "4",
+            "name": "EEG",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 570,
+            "position_y": 336
+        },
+        {
+            "attributes": {
+            },
+            "id": "6",
+            "name": "Grid",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 210,
+            "position_y": 338
+        },
+        {
+            "attributes": {
+            },
+            "id": "7",
+            "name": "Type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 184,
+            "position_y": 753
+        },
+        {
+            "attributes": {
+            },
+            "id": "8",
+            "name": "Output",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 395,
+            "position_y": 396
+        },
+        {
+            "attributes": {
+                "path": "lib/eeg/med_dummy.py"
+            },
+            "id": "17",
+            "name": "Libmed dummy Worker",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 1033,
+            "position_y": 446
+        },
+        {
+            "attributes": {
+            },
+            "id": "18",
+            "name": "ServerSideWorker",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 967,
+            "position_y": 328
+        },
+        {
+            "attributes": {
+            },
+            "id": "22",
+            "name": "Python",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 1147,
+            "position_y": 326
+        },
+        {
+            "attributes": {
+                "default": 3,
+                "domain": "Idle, Ohmmeter, Calibration, Data"
+            },
+            "id": "24",
+            "name": "Mode",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 721,
+            "position_y": 566
+        },
+        {
+            "attributes": {
+            },
+            "id": "25",
+            "name": "Setting",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 758,
+            "position_y": 679
+        },
+        {
+            "attributes": {
+            },
+            "id": "26",
+            "name": "Enum",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 584,
+            "position_y": 692
+        },
+        {
+            "attributes": {
+            },
+            "id": "31",
+            "name": "Labels",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 579,
+            "position_y": 475
+        },
+        {
+            "attributes": {
+                "default": 3
+            },
+            "id": "36",
+            "name": "Channels",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 890,
+            "position_y": 564
+        },
+        {
+            "attributes": {
+            },
+            "id": "37",
+            "name": "Number",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 897,
+            "position_y": 756
+        },
+        {
+            "attributes": {
+            },
+            "id": "44",
+            "name": "Array",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 257,
+            "position_y": 475
+        },
+        {
+            "attributes": {
+            },
+            "id": "45",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 338,
+            "position_y": 566
+        }
+    ],
+    "relations": [
+        {
+            "attributes": {
+            },
+            "destination_node_id": "2",
+            "id": "9",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "1"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "1",
+            "id": "10",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "4",
+            "id": "11",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "8",
+            "id": "12",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "4"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "16",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "6"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "18",
+            "id": "19",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "3",
+            "id": "20",
+            "name": "is_instance",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "21",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "4"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "22",
+            "id": "23",
+            "name": "language",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "24",
+            "id": "27",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "25",
+            "id": "28",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "24"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "26",
+            "id": "29",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "24"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "30",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "26"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "31",
+            "id": "33",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "8",
+            "id": "35",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "36",
+            "id": "39",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "37",
+            "id": "40",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "36"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "42",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "37"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "25",
+            "id": "43",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "36"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "45",
+            "id": "46",
+            "name": "",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "45"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "47",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "45"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "48",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "44"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "44",
+            "id": "49",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "45",
+            "id": "50",
+            "name": "base_type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        }
+    ],
+    "visualize_ont_path": ""
+}

--- a/kb/eeg/med_ebneuro.ont
+++ b/kb/eeg/med_ebneuro.ont
@@ -1,0 +1,389 @@
+{
+    "last_id": "49",
+    "namespaces": {
+        "default": "http://knova.ru/user/1608539508915",
+        "ontolis-avis": "http://knova.ru/ontolis-avis",
+        "owl": "http://www.w3.org/2002/07/owl",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+        "xsd": "http://www.w3.org/2001/XMLSchema"
+    },
+    "nodes": [
+        {
+            "attributes": {
+            },
+            "id": "1",
+            "name": "DataSource",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 675,
+            "position_y": 348
+        },
+        {
+            "attributes": {
+            },
+            "id": "2",
+            "name": "Root",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 608,
+            "position_y": 200
+        },
+        {
+            "attributes": {
+            },
+            "id": "3",
+            "name": "EBNeuro EEG",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 776,
+            "position_y": 448
+        },
+        {
+            "attributes": {
+            },
+            "id": "4",
+            "name": "EEG",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 570,
+            "position_y": 336
+        },
+        {
+            "attributes": {
+            },
+            "id": "6",
+            "name": "Grid",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 205,
+            "position_y": 338
+        },
+        {
+            "attributes": {
+            },
+            "id": "7",
+            "name": "Type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 215,
+            "position_y": 755
+        },
+        {
+            "attributes": {
+            },
+            "id": "8",
+            "name": "Output",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 409,
+            "position_y": 417
+        },
+        {
+            "attributes": {
+                "path": "lib/eeg/med_ebneuro.py"
+            },
+            "id": "17",
+            "name": "Libmed ebneuro Worker",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 1009,
+            "position_y": 432
+        },
+        {
+            "attributes": {
+            },
+            "id": "18",
+            "name": "ServerSideWorker",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 1048,
+            "position_y": 287
+        },
+        {
+            "attributes": {
+            },
+            "id": "22",
+            "name": "Python",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 911,
+            "position_y": 271
+        },
+        {
+            "attributes": {
+                "default": 3,
+                "domain": "Idle, Ohmmeter, Calibration, Data"
+            },
+            "id": "24",
+            "name": "Mode",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 637,
+            "position_y": 545
+        },
+        {
+            "attributes": {
+            },
+            "id": "25",
+            "name": "Setting",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 795,
+            "position_y": 669
+        },
+        {
+            "attributes": {
+            },
+            "id": "26",
+            "name": "Enum",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 445,
+            "position_y": 624
+        },
+        {
+            "attributes": {
+            },
+            "id": "31",
+            "name": "Labels",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 579,
+            "position_y": 475
+        },
+        {
+            "attributes": {
+                "default": "192.168.171.81"
+            },
+            "id": "36",
+            "name": "Address",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 943,
+            "position_y": 571
+        },
+        {
+            "attributes": {
+            },
+            "id": "37",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 922,
+            "position_y": 746
+        },
+        {
+            "attributes": {
+            },
+            "id": "44",
+            "name": "Array",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 263,
+            "position_y": 474
+        },
+        {
+            "attributes": {
+            },
+            "id": "45",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 307,
+            "position_y": 546
+        }
+    ],
+    "relations": [
+        {
+            "attributes": {
+            },
+            "destination_node_id": "2",
+            "id": "9",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "1"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "1",
+            "id": "10",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "4",
+            "id": "11",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "8",
+            "id": "12",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "4"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "16",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "6"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "18",
+            "id": "19",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "3",
+            "id": "20",
+            "name": "is_instance",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "21",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "4"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "22",
+            "id": "23",
+            "name": "language",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "24",
+            "id": "27",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "25",
+            "id": "28",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "24"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "26",
+            "id": "29",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "24"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "30",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "26"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "31",
+            "id": "33",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "8",
+            "id": "35",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "36",
+            "id": "39",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "37",
+            "id": "40",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "36"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "42",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "37"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "25",
+            "id": "43",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "36"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "44",
+            "id": "46",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "45",
+            "id": "47",
+            "name": "base_type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "48",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "44"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "49",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "45"
+        }
+    ],
+    "visualize_ont_path": ""
+}

--- a/kb/eeg/med_openbci.ont
+++ b/kb/eeg/med_openbci.ont
@@ -1,0 +1,407 @@
+{
+    "last_id": "53",
+    "namespaces": {
+        "default": "http://knova.ru/user/1608539508915",
+        "ontolis-avis": "http://knova.ru/ontolis-avis",
+        "owl": "http://www.w3.org/2002/07/owl",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema",
+        "xsd": "http://www.w3.org/2001/XMLSchema"
+    },
+    "nodes": [
+        {
+            "attributes": {
+            },
+            "id": "1",
+            "name": "DataSource",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 675,
+            "position_y": 348
+        },
+        {
+            "attributes": {
+            },
+            "id": "2",
+            "name": "Root",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 608,
+            "position_y": 200
+        },
+        {
+            "attributes": {
+            },
+            "id": "3",
+            "name": "OpenBCI EEG",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 776,
+            "position_y": 448
+        },
+        {
+            "attributes": {
+            },
+            "id": "4",
+            "name": "EEG",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 570,
+            "position_y": 336
+        },
+        {
+            "attributes": {
+            },
+            "id": "6",
+            "name": "Grid",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 209,
+            "position_y": 347
+        },
+        {
+            "attributes": {
+            },
+            "id": "7",
+            "name": "Type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 209,
+            "position_y": 782
+        },
+        {
+            "attributes": {
+            },
+            "id": "8",
+            "name": "Output",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 416,
+            "position_y": 397
+        },
+        {
+            "attributes": {
+                "path": "lib/eeg/med_openbci.py"
+            },
+            "id": "17",
+            "name": "Libmed openbci Worker",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 1009,
+            "position_y": 432
+        },
+        {
+            "attributes": {
+            },
+            "id": "18",
+            "name": "ServerSideWorker",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 1048,
+            "position_y": 287
+        },
+        {
+            "attributes": {
+            },
+            "id": "22",
+            "name": "Python",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 911,
+            "position_y": 271
+        },
+        {
+            "attributes": {
+                "default": 3,
+                "domain": "Idle, Ohmmeter, Calibration, Data"
+            },
+            "id": "24",
+            "name": "Mode",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 637,
+            "position_y": 545
+        },
+        {
+            "attributes": {
+            },
+            "id": "25",
+            "name": "Setting",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 795,
+            "position_y": 669
+        },
+        {
+            "attributes": {
+            },
+            "id": "26",
+            "name": "Enum",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 555,
+            "position_y": 657
+        },
+        {
+            "attributes": {
+            },
+            "id": "31",
+            "name": "Labels",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 579,
+            "position_y": 475
+        },
+        {
+            "attributes": {
+                "default": "/dev/ttyUSB0"
+            },
+            "id": "36",
+            "name": "Port",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 943,
+            "position_y": 571
+        },
+        {
+            "attributes": {
+            },
+            "id": "37",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 896,
+            "position_y": 762
+        },
+        {
+            "attributes": {
+            },
+            "id": "44",
+            "name": "Array",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 273,
+            "position_y": 478
+        },
+        {
+            "attributes": {
+            },
+            "id": "45",
+            "name": "String",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "position_x": 353,
+            "position_y": 548
+        }
+    ],
+    "relations": [
+        {
+            "attributes": {
+            },
+            "destination_node_id": "2",
+            "id": "9",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "1"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "1",
+            "id": "10",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "4",
+            "id": "11",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "8",
+            "id": "12",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "4"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "16",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "6"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "18",
+            "id": "19",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "3",
+            "id": "20",
+            "name": "is_instance",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "6",
+            "id": "21",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "4"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "22",
+            "id": "23",
+            "name": "language",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "17"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "24",
+            "id": "27",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "25",
+            "id": "28",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "24"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "26",
+            "id": "29",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "24"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "30",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "26"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "31",
+            "id": "33",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "8",
+            "id": "35",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "36",
+            "id": "39",
+            "name": "has",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "3"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "37",
+            "id": "40",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "36"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "42",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "37"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "25",
+            "id": "43",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "36"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "44",
+            "id": "46",
+            "name": "",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "44"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "44",
+            "id": "47",
+            "name": "",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "44"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "48",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "44"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "7",
+            "id": "49",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "45"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "44",
+            "id": "52",
+            "name": "is_a",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        },
+        {
+            "attributes": {
+            },
+            "destination_node_id": "45",
+            "id": "53",
+            "name": "base_type",
+            "namespace": "http://knova.ru/user/1611500337650",
+            "source_node_id": "31"
+        }
+    ],
+    "visualize_ont_path": ""
+}

--- a/lib/chartjs/eegchart.js
+++ b/lib/chartjs/eegchart.js
@@ -1,53 +1,49 @@
 
 if (IN_VISUALIZATION) {
     if (HAS_INPUT["EEG"]) {
-        var grid = INPUT["EEG"];
+      var grid = INPUT["EEG"];
         if (grid) {
             var charts = CACHE["charts"];
-            // var n = grid.length - 1;
-            var m = grid[1][0].length;
-            var hL = 100;
-            //console.log(grid);
+            var history_length = SETTINGS_VAL["History"];
+            var channel_count = grid.length;
+            var sample_count = grid[0].length;
             if (charts) {
-                for (var i = 0; i < grid[0].length; ++i) {
-                    // var elName = grid[0][i];
-                    // var elVal = grid[1][i];
-                    // var m = grid[i].length;
+                for (var i = 0; i < channel_count; ++i) {
                     var data = charts[i].data.datasets[0].data;
-                    for (var j = m; j < hL; ++j)
-                        data[j - m] = data[j];
-                    for (var j = hL - m; j < hL; ++j)
-                        data[j] = grid[1][i][j - hL + m];
+                    for (var j = sample_count; j < history_length; ++j)
+                        data[j - sample_count] = data[j];
+                    for (var j = history_length - sample_count; j < history_length; ++j)
+                        data[j] = grid[i][j - history_length + sample_count];
                     charts[i].update();
                 }
-                // for (var i = 0; i < n; ++i) {
-                //     var m = grid[i].length;
-                //     var data = charts[i].data.datasets[0].data;
-                
-                // }
             } else {
                 charts = [];
                 var div = document.createElement("div");
-		var n = grid[0].length;
-                for (var i = 0; i < n; ++i) {
+                for (var i = 0; i < channel_count; ++i) {
                     var subDiv = document.createElement("div");
-                    subDiv.style.height = (window.innerHeight / n) + "px";
+                    subDiv.style.height = (window.innerHeight / channel_count) + "px";
                     var cvs = document.createElement("canvas");
                     var ctx = cvs.getContext("2d");
                     var data = [];
                     var labels = [];
-                    for (var j = 0; j < hL; ++j) {
-                        data.push({
-                            y: j < hL - m ? 0 : grid[1][i][j - hL + m]
-                        });
+                    for (var j = 0; j < history_length; ++j) {
+                        if (j < sample_count) {
+                            data.push({ y: grid[i][j] });
+                        } else {
+                            data.push({ y: 0 });
+                        }
                         labels.push(j);
+                    }
+                    channel_name = "channel " + i;
+                    if (HAS_INPUT["Labels"]) {
+                        channel_name = INPUT["Labels"][i];
                     }
                     var chart = new Chart(ctx, {
                         type: "line",
                         data: {
                             labels: labels,
                             datasets: [{
-                                label: "channel " + i,
+                                label: channel_name,
                                 borderColor: "#000",
                                 fill: false,
                                 lineTension: 0,

--- a/lib/eeg/impedance.js
+++ b/lib/eeg/impedance.js
@@ -127,7 +127,10 @@ if (IN_VISUALIZATION) {
         var th = SETTINGS_VAL["Threshold"];
         var cap = th * 2;
         var svg = electrodes.contentDocument;
-        var eeg = INPUT["EEG"];
+        var eeg_in = INPUT["EEG"];
+        var labels_in = INPUT["Labels"];
+        var eeg_T = eeg_in.map(x => x[0])
+        var eeg = [labels_in, eeg_T];
         var vals = CACHE["Values"];
         if ($("#impedance-scale").height() === 0) {
             $("#impedance-scale").height(svg.documentElement.clientHeight - 

--- a/lib/eeg/libmed.py
+++ b/lib/eeg/libmed.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import time
+
+try:
+    import pylibmed as med
+except:
+    raise RuntimeError("This feature is not available for this deployment") from None
+
+
+EEG_KEY = "EEG"
+EEG_current_mode_KEY = "EEG_current_mode"
+
+def parse_options(options, ignore=[]):
+    ret = {}
+    for key in options:
+        if key not in ignore:
+            ret[key.lower().replace(" ", "_")] = options[key]
+
+    return ret
+
+
+sample_count = 16
+
+# Mode enum, aligned with the ontology.
+MODE_IDLE        = 0
+MODE_OHM_METER   = 1
+MODE_CALIBRATION = 2
+MODE_SAMPLING    = 3
+
+MODE_MAP = {
+    MODE_IDLE:          med.MED_EEG_IDLE,
+    MODE_OHM_METER:     med.MED_EEG_IMPEDANCE,
+    MODE_CALIBRATION:   med.MED_EEG_TEST,
+    MODE_SAMPLING:      med.MED_EEG_SAMPLING,
+}
+
+def tick(driver_name, MODE, SETTINGS_VAL, OUTPUT, GLOB, PROCESS):
+    if MODE == "INITIALIZATION":
+        # Create a new Eeg object and save it into GLOB to use on consecutive ticks.
+        # The initial connection (if needed) happens on creation of the object.
+        # We will get an exception here if the connection fails.
+        opts = parse_options(SETTINGS_VAL, ["Mode"])
+        opts["verbosity"] = 3
+        eeg = med.Eeg(driver_name, opts)
+        GLOB[EEG_KEY] = eeg
+        GLOB[EEG_current_mode_KEY] = None
+
+
+    elif MODE == "RUNNING":
+        eeg = GLOB[EEG_KEY]
+
+        # Pass mode change to the device if needed.
+        current_mode = GLOB[EEG_current_mode_KEY]
+        new_mode = int(SETTINGS_VAL["Mode"])
+        if new_mode != current_mode:
+            GLOB[EEG_current_mode_KEY] = new_mode
+            current_mode = new_mode
+            eeg.set_mode(MODE_MAP[new_mode])
+
+        labels = eeg.get_channels()
+        OUTPUT["Labels"] = labels
+
+        if current_mode == MODE_IDLE:
+            pass
+        elif current_mode == MODE_OHM_METER:
+            # Produces an 1d array of values, we have to reshape it to fit the
+            # usual format.
+            data = eeg.get_impedance()
+            OUTPUT["EEG"] = [ [val] for val in data.tolist() ]
+        else:
+            # Produces a 2d array with samples.
+            data = eeg.sample(sample_count)
+            OUTPUT["EEG"] = data.T.tolist()
+
+
+    elif MODE == "DESTRUCTION":
+        # The object must be destroued in order to tear down the connections and
+        # any leftover resources. Do it explicitly here as otherwise the object
+        # (and any connection to it) will hang in GLOB and won't be GC'd
+        del GLOB[EEG_KEY]
+        del GLOB[EEG_current_mode_KEY]
+
+
+    PROCESS()

--- a/lib/eeg/med_dummy.py
+++ b/lib/eeg/med_dummy.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from .libmed import *
+
+tick("dummy", MODE, SETTINGS_VAL, OUTPUT, GLOB, PROCESS)

--- a/lib/eeg/med_ebneuro.py
+++ b/lib/eeg/med_ebneuro.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from .libmed import *
+
+tick("ebneuro", MODE, SETTINGS_VAL, OUTPUT, GLOB, PROCESS)

--- a/lib/eeg/med_openbci.py
+++ b/lib/eeg/med_openbci.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from .libmed import *
+
+tick("openbci", MODE, SETTINGS_VAL, OUTPUT, GLOB, PROCESS)

--- a/lib/eeg/montage_transform.py
+++ b/lib/eeg/montage_transform.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+from .montage import Montage
+
+if MODE == "INITIALIZATION":
+    GLOB["MT_old_montage_name"] = None
+
+
+elif MODE == "RUNNING":
+    data = INPUT["EEG In"]
+    labels = None
+    montage : Montage = INPUT["Montage Schema"] if HAS_INPUT["Montage Schema"] else None
+
+    montage_name = SETTINGS_VAL["Montage Name"]
+
+    if montage is not None:
+        frames = np.asarray(data)
+        labels, frames = montage.transform_frame_by_montage(frames, montage_name)
+        data = frames.tolist()
+        
+
+    OUTPUT["EEG Out"] = data
+    OUTPUT["Labels"] = labels
+
+
+elif MODE == "DESTRUCTION":
+    pass
+
+
+PROCESS()

--- a/lib/eeg/montage_worker.py
+++ b/lib/eeg/montage_worker.py
@@ -3,8 +3,22 @@
 from .montage import Montage
 
 MP_SETTING_MONTAGE_PATH = 'Path'
-
 MP_OUTPUT_MONTAGE_SCHEMA = 'Montage Schema'
 
-path = SETTINGS_VAL[MP_SETTING_MONTAGE_PATH]
-OUTPUT[MP_OUTPUT_MONTAGE_SCHEMA] = Montage(path)
+if MODE == "INITIALIZATION":
+    GLOB["MP_old_path"] = None
+
+
+elif MODE == "RUNNING":
+    path = SETTINGS_VAL[MP_SETTING_MONTAGE_PATH]
+    old_path = GLOB["MP_old_path"]
+    if old_path != path:
+        GLOB["MP_old_path"] = path
+        CACHE["MP_Montage"] = Montage(path)
+
+    OUTPUT[MP_OUTPUT_MONTAGE_SCHEMA] = CACHE["MP_Montage"]
+
+
+elif MODE == "DESTRUCTION":
+    del CACHE["MP_Montage"]
+    del GLOB["MP_old_path"]

--- a/server/execer.py
+++ b/server/execer.py
@@ -88,7 +88,9 @@ class Execer(Thread):
         for inputNode in inputNodes:
             inputInst = self.get_belonging_instance(instNode, inputNode)
             outputInst = first(self.taskOnto.get_nodes_linked_to(inputInst, "is_used"))
-            hasInputs[inputNode.name] = outputInst is not None
+            # FIXME: Sometimes there are two nodes of the same name with only
+            # one actually connected. Set to True iif at least one is used.
+            hasInputs[inputNode.name] = outputInst is not None or hasInputs[inputNode.name]
             if outputInst and (outputInst.id in self.buffer):
                 inputs[inputNode.name] = self.buffer[outputInst.id]
         return inputs, hasInputs


### PR DESCRIPTION
Add three EEG providers:
- EBNeuro
- OpenBCI
- Dummy (dubious data generator)
based on libmed (https://github.com/icosaeder/libmed still yet to be transfered to scivi-tools)

Adapt some existing operators to use them:
- EEG Chart to use extra label data if available
- Impedance to also use dedicated label data, generated via new Montage Transform filter

